### PR TITLE
assert_equal function to handle unexpected errors

### DIFF
--- a/unittest.sml
+++ b/unittest.sml
@@ -19,7 +19,7 @@ fun raises (f: 'a -> 'b, args: 'a, e: exn) =
         assert_eq (exnName thrown_e, exnName e)
 
 
-fun assert_all_i (nil, _)          = raise InternalAssert
+fun assert_all_i (nil, _)          = OK
 |   assert_all_i (OK :: nil, i)    = OK
 |   assert_all_i (FAIL :: nil, i)  = FAILIDX i
 |   assert_all_i (OK :: tail, i)   = assert_all_i (tail, i + 1)

--- a/unittest.sml
+++ b/unittest.sml
@@ -1,7 +1,7 @@
 
 exception InternalAssert;
 
-datatype assert_result = OK | FAIL | FAILIDX of int;
+datatype assert_result = OK | FAIL | FAILIDX of int | FAILEXCEPT of exn;
 
 
 fun assert (e: bool) =
@@ -12,6 +12,9 @@ fun assert (e: bool) =
 fun assert_eq (e1: ''a, e2: ''a) =
     assert (e1 = e2);
 
+fun assert_equal (f: 'a -> ''b, args: 'a, e: ''b) =
+    (assert (f (args) = e))
+    handle throw_e => FAILEXCEPT throw_e;
 
 fun raises (f: 'a -> 'b, args: 'a, e: exn) =
     (f args; FAIL)
@@ -20,10 +23,11 @@ fun raises (f: 'a -> 'b, args: 'a, e: exn) =
 
 
 fun assert_all_i (nil, _)          = OK
-|   assert_all_i (OK :: nil, i)    = OK
+|   assert_all_i (OK :: nil, _)    = OK
 |   assert_all_i (FAIL :: nil, i)  = FAILIDX i
 |   assert_all_i (OK :: tail, i)   = assert_all_i (tail, i + 1)
 |   assert_all_i (FAIL :: tail, i) = FAILIDX i
+|   assert_all_i (FAILEXCEPT e:: _, _) = FAILEXCEPT e
 |   assert_all_i (_, _)            = raise InternalAssert;
 
 
@@ -31,4 +35,5 @@ fun test (name: string, asserts: assert_result list) =
     case assert_all_i (asserts, 0) of
         OK        => (print ("OK\t" ^ name ^ "\n"); ())
     |   FAIL      => (print ("FAIL\t" ^ name ^ "\n"); ())
-    |   FAILIDX i => (print ("FAIL\t" ^ name ^ " (at assert #" ^ Int.toString(i) ^ ")\n"); ());
+    |   FAILIDX i => (print ("FAIL\t" ^ name ^ " (at assert #" ^ Int.toString(i) ^ ")\n"); ())
+    |   FAILEXCEPT ex => (print("FAIL \t" ^ name ^ " (exception: " ^ exnName ex ^ ")\n"); ());


### PR DESCRIPTION
Added function assert_equal which in comparison to assert_eq can handle unexpected exceptions.

**I recommend to use assert_equal above assert_eq**, since if an unexpected exception is triggered with the latter we will not get a description why the script existed with a status code of 1.

Usage is similar to assert_eq only that instead of triggering the function in the test, we pass on the arguments to the function - just like with the raise function.

example:
```sml
test("bad_test", [
  assert_equal( (fn x => hd x), [], 1) (* This will trigger a List empty exception *)
]);
```